### PR TITLE
Update snapshot.ml for changes in Spacetime_lib

### DIFF
--- a/src/snapshot.ml
+++ b/src/snapshot.ml
@@ -86,7 +86,7 @@ let initial snapshot =
   let time = Spacetime_lib.Snapshot.time snapshot in
   let stats = Spacetime_lib.Snapshot.stats snapshot in
   let entries = Spacetime_lib.Snapshot.entries snapshot in
-  create true 0 time stats entries
+  create true 0 time stats (Spacetime_lib.Entries.elements entries)
 
 let project t addr =
   match Address.Map.find addr t.index with


### PR DESCRIPTION
prof_alloc does not compile with (the current master of Spacetime_lib) commit f11ce03
Because there is a set given, where a list is expected. This is a straightforward fix
and no functionality is changed.

This appears to be an oversight from the previous df98891
