### PR TITLE
Support for displaying call counts in the terminal viewer

### DIFF
--- a/src/path.ml
+++ b/src/path.ml
@@ -3,6 +3,8 @@ type mode =
   | Bytes
   | Blocks
   | Allocations
+  | Indirect_calls
+  | Direct_calls
 
 type kind =
   | Reduced
@@ -35,6 +37,8 @@ let project t addr = { t with addresses = addr :: t.addresses }
 let bytes_mode = "/bytes"
 let blocks_mode = "/block"
 let allocations_mode = "/alloc"
+let indirect_calls_mode = "/indirect-calls"
+let direct_calls_mode = "/direct-calls"
 
 let mode_len =
   let bytes_len = String.length bytes_mode in
@@ -94,6 +98,7 @@ let of_string s =
           if mode = bytes_mode then Some Bytes
           else if mode = blocks_mode then Some Blocks
           else if mode = allocations_mode then Some Allocations
+          else if mode = indirect_calls_mode then Some Indirect_calls
           else None
         in
         let kind =
@@ -143,3 +148,4 @@ let mode_to_display_string = function
   | Bytes -> "Live words"
   | Blocks -> "Live blocks"
   | Allocations -> "All allocated words"
+  | Indirect_calls -> "Indirect calls"

--- a/src/path.mli
+++ b/src/path.mli
@@ -3,6 +3,8 @@ type mode =
   | Bytes
   | Blocks
   | Allocations
+  | Indirect_calls
+  | Direct_calls
 
 type kind =
   | Reduced

--- a/src/snapshot.mli
+++ b/src/snapshot.mli
@@ -4,7 +4,7 @@ type t
 
 val time : t -> float
 
-val stats : t -> Spacetime_lib.Stats.t
+val stats : t -> Spacetime_lib.Stats.t option
 
 val initial : Spacetime_lib.Snapshot.t -> inverted:bool -> t
 
@@ -24,7 +24,12 @@ val blocks : t -> Address.t -> int
 
 val allocations : t -> Address.t -> int
 
+val indirect_calls : t -> Address.t -> int
+
+val direct_calls : t -> Address.t -> int
+
 val to_json : Path.mode -> Location.t Address.Map.t -> t -> Yojson.Basic.json
 
-val to_summary_list : ?mode:[ `Words | `Blocks | `Allocations ] ->
-  Location.t Address.Map.t -> t -> (Address.t * string * int) list
+val to_summary_list
+   : ?mode:[ `Words | `Blocks | `Allocations | `Indirect_calls | `Direct_calls ]
+  -> Location.t Address.Map.t -> t -> (Address.t * string * int) list

--- a/src/viewer.mli
+++ b/src/viewer.mli
@@ -1,2 +1,3 @@
 
 val show : Series.t -> unit
+val show_calls : Series.t -> unit


### PR DESCRIPTION
This patch provides support, in the terminal viewer only, for viewing direct and indirect calls made during the execution of a program.