### PR TITLE
Update to cohttp.1.0.0

### DIFF
--- a/prof_spacetime.opam
+++ b/prof_spacetime.opam
@@ -9,7 +9,7 @@ dev-repo: "git://github.com/lpw25/prof_spacetime"
 depends: [
   "jbuilder" {build & >= "1.0+beta10"}
   "cmdliner"
-  "cohttp" {>= "0.99.0"}
+  "cohttp" {>= "1.0.0"}
   "cohttp-lwt-unix"
   "conduit"
   "conduit-lwt-unix"

--- a/src/serve.ml
+++ b/src/serve.ml
@@ -275,7 +275,7 @@ let serve ~address ~port ~title series =
   let server = Server.make ~callback () in
   let body =
     ctx >>= fun ctx ->
-    let ctx = Cohttp_lwt_unix_net.init ~ctx () in
+    let ctx = Cohttp_lwt_unix.Net.init ~ctx () in
     Server.create ~ctx ~mode server
   in
   Printf.printf "Serving on http://%s:%d/\n%!" address port;


### PR DESCRIPTION
cohttp.1.0.0 moved `Cohttp_lwt_unix_lwt` to `Cohttp_lwt_unix.Net`.

Signed-off-by: David Scott <dave@recoil.org>