### PR TITLE
Added diff option to compare processed profiles.

### DIFF
--- a/src/diff.ml
+++ b/src/diff.ml
@@ -1,0 +1,93 @@
+
+type diff =
+  { words: int
+  ; allocations: int
+  ; blocks: int
+  }
+
+let empty_diff = { allocations = 0; words = 0; blocks = 0 }
+
+module AllocMap = Map.Make(String)
+module NameSet = Set.Make(String)
+
+
+let get_alloc_map snapshot =
+  let rec loop snapshot acc =
+    Section.fold Section.(fun addr item acc ->
+      let value = Item.value item in
+
+      let words = Allocation.words value in
+      let allocations = Allocation.allocations value in
+      let blocks = Allocation.blocks value in
+
+      try
+        let display = Item.display item in
+        let name = String.sub display 0 (String.index display ':') in
+        acc |> AllocMap.update name (fun v -> Some (match v with
+          | None ->
+            { words; allocations; blocks }
+          | Some v ->
+            { words = words + v.words
+            ; allocations = allocations + v.allocations
+            ; blocks = blocks + v.blocks
+            }))
+      with
+        Not_found ->
+          loop (Item.select item) acc
+    ) snapshot acc
+  in loop snapshot AllocMap.empty
+
+let get_keys map =
+  AllocMap.fold (fun k _ acc -> NameSet.add k acc) map NameSet.empty
+
+let diff_maps map0 map1 =
+  let keys = NameSet.union (get_keys map0) (get_keys map1) in
+  let diffs = NameSet.elements keys
+    |> List.map (fun key ->
+      let diff0 = try AllocMap.find key map0 with Not_found -> empty_diff in
+      let diff1 = try AllocMap.find key map1 with Not_found -> empty_diff in
+      let diff =
+        { words = diff0.words - diff1.words
+        ; allocations = diff0.allocations - diff1.allocations
+        ; blocks = diff0.blocks - diff1.blocks
+        }
+      in (key, diff))
+    |> List.filter (fun (k, { allocations }) -> allocations != 0)
+  in
+
+  let max_length = NameSet.fold (fun n l -> max l (String.length n)) keys 0 in
+
+  let padded_string i =
+    let str = (if i < 0 then "" else "+") ^ string_of_int i in
+    let len = String.length str in
+    if len < 14 then
+      (String.make (14 - len) ' ') ^ str
+    else
+      str
+  in
+
+  Printf.printf "File%s          Words    Allocations         Blocks\n"
+      (String.make (max_length - 4) ' ');
+
+  diffs
+    |> List.filter (fun (_, d) -> d.words != 0)
+    |> List.sort (fun (_, a) (_, b) -> a.words - b.words)
+    |> List.iter (fun (k, { allocations; words; blocks }) ->
+      Printf.printf "%s%s %s %s %s\n"
+          k
+          (String.make (max_length - String.length k) ' ')
+          (padded_string words)
+          (padded_string allocations)
+          (padded_string blocks))
+
+let compare_snapshots snapshot0 snapshot1 =
+  let a0 = Snapshot.allocation_entries ~inverted:false snapshot0 in
+  let a1 = Snapshot.allocation_entries ~inverted:false snapshot1 in
+  diff_maps (get_alloc_map a0) (get_alloc_map a1)
+
+let diff ref data =
+  match List.rev (Series.snapshots ref), List.rev (Series.snapshots data) with
+  | snapshot0 :: _, snapshot1 :: _ ->
+    compare_snapshots snapshot0 snapshot1
+  | _, _ ->
+    Printf.eprintf "Empty snaphot!\n"

--- a/src/diff.ml
+++ b/src/diff.ml
@@ -15,34 +15,33 @@ let get_alloc_map snapshot =
   let rec loop snapshot acc =
     Section.fold Section.(fun addr item acc ->
       let value = Item.value item in
-
       let words = Allocation.words value in
       let allocations = Allocation.allocations value in
       let blocks = Allocation.blocks value in
-
       try
         let display = Item.display item in
         let name = String.sub display 0 (String.index display ':') in
-        acc |> AllocMap.update name (fun v -> Some (match v with
+        AllocMap.update name (fun v -> Some (match v with
           | None ->
             { words; allocations; blocks }
           | Some v ->
             { words = words + v.words
             ; allocations = allocations + v.allocations
             ; blocks = blocks + v.blocks
-            }))
-      with
-        Not_found ->
-          loop (Item.select item) acc
+            }
+        )) acc
+      with Not_found -> loop (Item.select item) acc
     ) snapshot acc
-  in loop snapshot AllocMap.empty
+  in
+  loop snapshot AllocMap.empty
 
 let get_keys map =
   AllocMap.fold (fun k _ acc -> NameSet.add k acc) map NameSet.empty
 
 let diff_maps map0 map1 =
   let keys = NameSet.union (get_keys map0) (get_keys map1) in
-  let diffs = NameSet.elements keys
+  let diffs =
+    NameSet.elements keys
     |> List.map (fun key ->
       let diff0 = try AllocMap.find key map0 with Not_found -> empty_diff in
       let diff1 = try AllocMap.find key map1 with Not_found -> empty_diff in
@@ -51,24 +50,18 @@ let diff_maps map0 map1 =
         ; allocations = diff0.allocations - diff1.allocations
         ; blocks = diff0.blocks - diff1.blocks
         }
-      in (key, diff))
+      in
+      (key, diff))
     |> List.filter (fun (k, { allocations }) -> allocations != 0)
   in
-
   let max_length = NameSet.fold (fun n l -> max l (String.length n)) keys 0 in
-
   let padded_string i =
     let str = (if i < 0 then "" else "+") ^ string_of_int i in
     let len = String.length str in
-    if len < 14 then
-      (String.make (14 - len) ' ') ^ str
-    else
-      str
+    if len < 14 then (String.make (14 - len) ' ') ^ str else str
   in
-
-  Printf.printf "File%s          Words    Allocations         Blocks\n"
-      (String.make (max_length - 4) ' ');
-
+  let pad = String.make (max_length - 4) ' ' in
+  Printf.printf "File%s          Words    Allocations         Blocks\n" pad;
   diffs
     |> List.filter (fun (_, d) -> d.words != 0)
     |> List.sort (fun (_, a) (_, b) -> a.words - b.words)

--- a/src/diff.mli
+++ b/src/diff.mli
@@ -1,0 +1,5 @@
+
+val diff
+  :  Series.t
+  -> Series.t
+  -> unit

--- a/src/section.ml
+++ b/src/section.ml
@@ -213,3 +213,6 @@ let select t addr =
 
 let fold f t init =
   Address.Map.fold f t init
+
+let iter f t =
+  Address.Map.iter f t

--- a/src/section.mli
+++ b/src/section.mli
@@ -72,3 +72,5 @@ val project : 'a t -> Address.t -> 'a Item.t option
 val select : 'a t -> Address.t -> 'a t
 
 val fold : (Address.t -> 'a Item.t -> 'b -> 'b) -> 'a t -> 'b -> 'b
+
+val iter : (Address.t -> 'a Item.t -> unit) -> 'a t -> unit


### PR DESCRIPTION
`prof_spacetime diff profile_1 profile2` compares the number of memory blocks live at program exit time in each file in an application, producing an output along the lines of:

```
File                                                    Words    Allocations         Blocks
src/utils.ml                                          -753885        -765543        -225188
src/stdune/path.ml                                    -323112      -13199839        -107428
src/stdune/map.ml                                       +2496           -762           +836
string.ml                                             +139383        +325271         +21483
pervasives.ml                                         +449678       +1514358         -40923
```